### PR TITLE
Fix version check to work with both decimal and whole number versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,11 +17,15 @@ const extractJavaSemanticVersion = function (input) {
   }
   if (javaVersionLine) {
     const javaVersion = javaVersionLine.match(/"(.*?)"/i)[1]
-    const semanticVersion = javaVersion.match(/(\d+\.)?(\d+\.)?(\*|\d+)/i)
+    let semanticVersion
+    if(javaVersion.indexOf(".") == -1) { // Check if version is formatted as number
+      semanticVersion = [null, javaVersion, 0, 0]
+    } else {
+      semanticVersion = javaVersion.match(/([0-9]+)\.([0-9]+)\.([0-9]+)(_.*)?/i)
+    }
     const major = parseInt(semanticVersion[1])
     const minor = parseInt(semanticVersion[2])
     const patch = parseInt(semanticVersion[3])
-    const meta = semanticVersion[4]
     if (major === 1) {
       return {
         major: minor,

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const extractJavaSemanticVersion = function (input) {
   }
   if (javaVersionLine) {
     const javaVersion = javaVersionLine.match(/"(.*?)"/i)[1]
-    const semanticVersion = javaVersion.match(/([0-9]+)(_.*)?/i)
+    const semanticVersion = javaVersion.match(/(\d+\.)?(\d+\.)?(\*|\d+)/i)
     const major = parseInt(semanticVersion[1])
     const minor = parseInt(semanticVersion[2])
     const patch = parseInt(semanticVersion[3])

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const extractJavaSemanticVersion = function (input) {
   }
   if (javaVersionLine) {
     const javaVersion = javaVersionLine.match(/"(.*?)"/i)[1]
-    const semanticVersion = javaVersion.match(/([0-9]+)\.([0-9]+)\.([0-9]+)(_.*)?/i)
+    const semanticVersion = javaVersion.match(/([0-9]+)(_.*)?/i)
     const major = parseInt(semanticVersion[1])
     const minor = parseInt(semanticVersion[2])
     const patch = parseInt(semanticVersion[3])


### PR DESCRIPTION
I am using Java version 19 which returns the following version string `openjdk version "19" 2022-09-20`.

Unfortunately the current version regex doesn't support whole number versions, and `checkRequirements()` produces an error. I've adjusted the regex to work with both.